### PR TITLE
Flag stopped searching so script can be repeated.

### DIFF
--- a/sshagent.cmd
+++ b/sshagent.cmd
@@ -19,6 +19,7 @@ FOR /F "tokens=1-2" %%A IN ('cmd /c tasklist^|find /i "ssh-agent.exe"') DO @(IF 
 echo Finished looking...
 IF NOT DEFINED SSH_AGENT_PID (GOTO :startagent)
 CALL :setregistry
+set SSH_AGENT_SEARCHING=
 GOTO :eof
 
 :doAdds
@@ -27,6 +28,7 @@ GOTO :eof
 
 :wtf
  @echo "WTF"
+ set SSH_AGENT_SEARCHING=
  GOTO :eof
 
 :agentexists


### PR DESCRIPTION
I have a "mysterious" ssh-agent.exe running already (perhaps from a
Cygwin environment) that appears incompatible with MSYS which leads to
this script failing the first time usually... The untidied variable
prevents me from rerunning it without manually unsetting the variable.
